### PR TITLE
[CBS-86] Make ssm activation expiration date configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  expiration_date = timeadd(timestamp(), var.expiration_duration)
+}
+
 data "aws_iam_policy_document" "default" {
   version = "2012-10-17"
   statement {
@@ -91,10 +95,16 @@ resource "aws_ssm_activation" "default" {
   name               = var.name
   description        = "SSM Activation for ${var.name}"
   iam_role           = "${aws_iam_role.ssm_activation.id}"
+  expiration_date    = local.expiration_date
   registration_limit = 1
   depends_on         = ["aws_iam_role_policy_attachment.ssm_activation"]
-}
 
+  lifecycle {
+    ignore_changes = [
+      expiration_date
+    ]
+  }
+}
 
 resource "aws_ssm_parameter" "ssm_activation" {
   name   = "/${var.name}/iot/ssm-activation"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "expiration_duration" {
+  type        = string
+  default     = "24h"
+  description = "The expiration period of the SSM activation"
+}
+
 variable "name" {
   type        = string
   description = "The name of the edge device"


### PR DESCRIPTION
This PR makes the  [expiration date](https://www.terraform.io/docs/providers/aws/r/ssm_activation.html#expiration_date) of the SSM Activation configurable (default is 24 hours).


[_Timestamp behaviour is special_](https://www.terraform.io/docs/configuration/functions/timestamp.html)
