### PR TITLE
Terraform interpolation fixes and add missing tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,17 +83,18 @@ resource "aws_iam_role" "ssm_activation" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_activation" {
-  role       = "${aws_iam_role.ssm_activation.name}"
+  role       = aws_iam_role.ssm_activation.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
 resource "aws_ssm_activation" "default" {
   name               = var.name
   description        = "SSM Activation for ${var.name}"
-  iam_role           = "${aws_iam_role.ssm_activation.id}"
+  iam_role           = aws_iam_role.ssm_activation.id
   expiration_date    = timeadd(timestamp(), var.expiration_duration)
   registration_limit = 1
-  depends_on         = ["aws_iam_role_policy_attachment.ssm_activation"]
+  depends_on         = [aws_iam_role_policy_attachment.ssm_activation]
+  tags               = var.tags
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
This PR fixes interpolation warnings introduced in [Terraform 0.12.14](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#01214-november-13-2019). 

Also added  missing tags to the [aws_ssm_activation](https://www.terraform.io/docs/providers/aws/r/ssm_activation.html#tags)