### PR TITLE
More restrictive permissions, wildcards are evil

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,13 @@ data "aws_iam_policy_document" "default" {
   statement {
     effect = "Allow"
     actions = [
-      "greengrass:*"
+      "greengrass:AssumeRoleForGroup",
+      "greengrass:CreateCertificate",
+      "greengrass:GetDeployment",
+      "greengrass:GetDeploymentArtifacts",
+      "greengrass:UpdateCoreDeploymentStatus",
+      "greengrass:GetConnectivityInfo",
+      "greengrass:UpdateConnectivityInfo"
     ]
     resources = [
       "*"


### PR DESCRIPTION
More restrictive permissions for Greengrass, wildcards are evil and should not be used unless absolutely necessary. 