### PR TITLE
Add KMS key to the output

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,8 +40,18 @@ jobs:
           tf_actions_subcommand: validate
           tf_actions_comment: true
 
+  terraform-sec:
+    name: tfsec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform security scan
+        uses: triat/terraform-security-scan@v2.2.3
+
   terraform-docs:
     runs-on: ubuntu-latest
+    needs: [terraform-fmt, terraform-sec, terraform-validate]    
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -56,12 +66,3 @@ jobs:
           tf_docs_output_file: README.md
           tf_docs_output_method: inject
           tf_docs_find_dir: .
-
-  tfsec:
-    name: tfsec
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@master
-      - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.0.2

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 | certificate\_pem | Path of the SSM Parameter for IoT certificate pem |
 | certificate\_private\_key | Path of the SSM Parameter for IoT certificate private key |
 | certificate\_public\_key | Path of the SSM Parameter for IoT certificate public key |
+| kms\_key\_arn | KMS key arn used for encrypting SSM Parameters for edge devices |
+| kms\_key\_id | KMS key id used for encrypting SSM Parameters for edge devices |
 | name | Name of the thing |
 
 <!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_iot_thing_principal_attachment" "default" {
 }
 
 module "edgedevice_kms_key" {
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.3"
+  source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.1.6"
   name        = var.name
   description = "KMS key used for encrypting SSM Parameters for edge devices"
   tags        = var.tags
@@ -109,6 +109,7 @@ resource "aws_iam_role" "ssm_activation" {
   count              = local.create_role
   name               = "SSMActivation-${var.name}"
   assume_role_policy = data.aws_iam_policy_document.ssm_activation.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ssm_activation" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,13 @@ output "certificate_private_key" {
   value       = aws_ssm_parameter.private_key.name
   description = "Path of the SSM Parameter for IoT certificate private key"
 }
+
+output "kms_key_arn" {
+  value       = module.edgedevice_kms_key.arn
+  description = "KMS key arn used for encrypting SSM Parameters for edge devices"
+}
+
+output "kms_key_id" {
+  value       = module.edgedevice_kms_key.id
+  description = "KMS key id used for encrypting SSM Parameters for edge devices"
+}


### PR DESCRIPTION
This PR adds the KMS key to the output so this can be used in other places, for instance to lock down the `kms:Decrypt` to this key).

Also:

- Added tags to the ssm_activation Role
- Bumped KMS module