### PR TITLE
Allow KMS key to be given as an input variable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.2.3
+        uses: triat/terraform-security-scan@v3.0.0
 
   terraform-docs:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 | certificate\_pem | Path of the SSM Parameter for IoT certificate pem |
 | certificate\_private\_key | Path of the SSM Parameter for IoT certificate private key |
 | certificate\_public\_key | Path of the SSM Parameter for IoT certificate public key |
+| kms\_key\_arn | KMS key arn used for encrypting SSM Parameters for edge devices |
+| kms\_key\_id | KMS key id used for encrypting SSM Parameters for edge devices |
 | name | Name of the thing |
 
 <!--- END_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | tags | A mapping of tags to assign to the SSM Parameter | `map(string)` | n/a | yes |
 | expiration\_duration | The expiration period of the SSM activation, default 4 weeks | `string` | `"672h"` | no |
 | iot\_policy | The policy to attach to the Thing | `string` | `null` | no |
+| kms\_key\_id | The KMS key ID used to encrypt all data | `string` | `null` | no |
 | ssm\_activation\_role\_id | The ID of the role to attach to the SSM activation | `string` | `null` | no |
 
 ## Outputs
@@ -33,8 +34,6 @@
 | certificate\_pem | Path of the SSM Parameter for IoT certificate pem |
 | certificate\_private\_key | Path of the SSM Parameter for IoT certificate private key |
 | certificate\_public\_key | Path of the SSM Parameter for IoT certificate public key |
-| kms\_key\_arn | KMS key arn used for encrypting SSM Parameters for edge devices |
-| kms\_key\_id | KMS key id used for encrypting SSM Parameters for edge devices |
 | name | Name of the thing |
 
 <!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -62,11 +62,18 @@ resource "aws_iot_thing_principal_attachment" "default" {
   thing     = aws_iot_thing.default.name
 }
 
+module "edgedevice_kms_key" {
+  source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.2.0"
+  name        = var.name
+  description = "KMS key used for encrypting SSM Parameters for edge devices"
+  tags        = var.tags
+}
+
 resource "aws_ssm_parameter" "certificate_pem" {
   name   = "/${var.name}/iot/certificate-pem"
   type   = "SecureString"
   value  = aws_iot_certificate.default.certificate_pem
-  key_id = var.kms_key_id
+  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
   tags   = var.tags
 }
 
@@ -74,7 +81,7 @@ resource "aws_ssm_parameter" "public_key" {
   name   = "/${var.name}/iot/public-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.public_key
-  key_id = var.kms_key_id
+  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
   tags   = var.tags
 }
 
@@ -82,7 +89,7 @@ resource "aws_ssm_parameter" "private_key" {
   name   = "/${var.name}/iot/private-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.private_key
-  key_id = var.kms_key_id
+  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
   tags   = var.tags
 }
 
@@ -131,6 +138,6 @@ resource "aws_ssm_parameter" "ssm_activation" {
   name   = "/${var.name}/iot/ssm-activation"
   type   = "SecureString"
   value  = aws_ssm_activation.default.activation_code
-  key_id = var.kms_key_id
+  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
   tags   = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -62,18 +62,11 @@ resource "aws_iot_thing_principal_attachment" "default" {
   thing     = aws_iot_thing.default.name
 }
 
-module "edgedevice_kms_key" {
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.2.0"
-  name        = var.name
-  description = "KMS key used for encrypting SSM Parameters for edge devices"
-  tags        = var.tags
-}
-
 resource "aws_ssm_parameter" "certificate_pem" {
   name   = "/${var.name}/iot/certificate-pem"
   type   = "SecureString"
   value  = aws_iot_certificate.default.certificate_pem
-  key_id = module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }
 
@@ -81,7 +74,7 @@ resource "aws_ssm_parameter" "public_key" {
   name   = "/${var.name}/iot/public-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.public_key
-  key_id = module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }
 
@@ -89,7 +82,7 @@ resource "aws_ssm_parameter" "private_key" {
   name   = "/${var.name}/iot/private-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.private_key
-  key_id = module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }
 
@@ -138,6 +131,6 @@ resource "aws_ssm_parameter" "ssm_activation" {
   name   = "/${var.name}/iot/ssm-activation"
   type   = "SecureString"
   value  = aws_ssm_activation.default.activation_code
-  key_id = module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,13 +32,3 @@ output "certificate_private_key" {
   value       = aws_ssm_parameter.private_key.name
   description = "Path of the SSM Parameter for IoT certificate private key"
 }
-
-output "kms_key_arn" {
-  value       = module.edgedevice_kms_key.arn
-  description = "KMS key arn used for encrypting SSM Parameters for edge devices"
-}
-
-output "kms_key_id" {
-  value       = module.edgedevice_kms_key.id
-  description = "KMS key id used for encrypting SSM Parameters for edge devices"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,13 @@ output "certificate_private_key" {
   value       = aws_ssm_parameter.private_key.name
   description = "Path of the SSM Parameter for IoT certificate private key"
 }
+
+output "kms_key_arn" {
+  value       = module.edgedevice_kms_key.arn
+  description = "KMS key arn used for encrypting SSM Parameters for edge devices"
+}
+
+output "kms_key_id" {
+  value       = module.edgedevice_kms_key.id
+  description = "KMS key id used for encrypting SSM Parameters for edge devices"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "expiration_duration" {
   description = "The expiration period of the SSM activation, default 4 weeks"
 }
 
+variable "kms_key_id" {
+  type        = string
+  default     = null
+  description = "The KMS key ID used to encrypt all data"
+}
+
 variable "iot_policy" {
   type        = string
   default     = null


### PR DESCRIPTION
Allow a specific KMS key to be specified.

Bumped TF security scan due to an issue (https://github.com/triat/terraform-security-scan/issues/41)