### PR TITLE
Remove KMS key from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@
 | certificate\_pem | Path of the SSM Parameter for IoT certificate pem |
 | certificate\_private\_key | Path of the SSM Parameter for IoT certificate private key |
 | certificate\_public\_key | Path of the SSM Parameter for IoT certificate public key |
-| kms\_key\_arn | KMS key arn used for encrypting SSM Parameters for edge devices |
-| kms\_key\_id | KMS key id used for encrypting SSM Parameters for edge devices |
 | name | Name of the thing |
 
 <!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -62,18 +62,11 @@ resource "aws_iot_thing_principal_attachment" "default" {
   thing     = aws_iot_thing.default.name
 }
 
-module "edgedevice_kms_key" {
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-kms?ref=v0.2.0"
-  name        = var.name
-  description = "KMS key used for encrypting SSM Parameters for edge devices"
-  tags        = var.tags
-}
-
 resource "aws_ssm_parameter" "certificate_pem" {
   name   = "/${var.name}/iot/certificate-pem"
   type   = "SecureString"
   value  = aws_iot_certificate.default.certificate_pem
-  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }
 
@@ -81,7 +74,7 @@ resource "aws_ssm_parameter" "public_key" {
   name   = "/${var.name}/iot/public-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.public_key
-  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }
 
@@ -89,7 +82,7 @@ resource "aws_ssm_parameter" "private_key" {
   name   = "/${var.name}/iot/private-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.private_key
-  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }
 
@@ -138,6 +131,6 @@ resource "aws_ssm_parameter" "ssm_activation" {
   name   = "/${var.name}/iot/ssm-activation"
   type   = "SecureString"
   value  = aws_ssm_activation.default.activation_code
-  key_id = var.kms_key_id != null ? var.kms_key_id : module.edgedevice_kms_key.id
+  key_id = var.kms_key_id
   tags   = var.tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,13 +32,3 @@ output "certificate_private_key" {
   value       = aws_ssm_parameter.private_key.name
   description = "Path of the SSM Parameter for IoT certificate private key"
 }
-
-output "kms_key_arn" {
-  value       = module.edgedevice_kms_key.arn
-  description = "KMS key arn used for encrypting SSM Parameters for edge devices"
-}
-
-output "kms_key_id" {
-  value       = module.edgedevice_kms_key.id
-  description = "KMS key id used for encrypting SSM Parameters for edge devices"
-}


### PR DESCRIPTION
If no KMS is given, the default `alias/aws/ssm` key is used. Else the KMS given is used