### PR TITLE
Add AWS Root certificate to SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | Name | Version |
 |------|---------|
 | aws | n/a |
+| http | n/a |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,10 @@ resource "aws_iot_certificate" "default" {
   active = true
 }
 
+data "http" "root_ca" {
+  url = "https://www.amazontrust.com/repository/AmazonRootCA1.pem"
+}
+
 resource "aws_iot_policy_attachment" "default" {
   policy = aws_iot_policy.default.name
   target = aws_iot_certificate.default.arn
@@ -82,6 +86,14 @@ resource "aws_ssm_parameter" "private_key" {
   name   = "/${var.name}/iot/private-key"
   type   = "SecureString"
   value  = aws_iot_certificate.default.private_key
+  key_id = var.kms_key_id
+  tags   = var.tags
+}
+
+resource "aws_ssm_parameter" "root_ca_crt" {
+  name   = "/${var.name}/iot/root-ca-crt"
+  type   = "SecureString"
+  value  = data.http.root_ca.body
   key_id = var.kms_key_id
   tags   = var.tags
 }


### PR DESCRIPTION
This PR adds the AWS Root certificate to SSM, next to the other certificate information. This might be handy in case the entire certificate chain is needed