### PR TITLE
Replace deprecated body with response_body

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+        uses: triat/terraform-security-scan@v3.0.3
 
   terraform-docs:
     runs-on: ubuntu-latest
-    needs: [terraform-fmt, terraform-sec, terraform-validate]    
+    needs: [terraform-fmt, terraform-sec, terraform-validate]
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_ssm_parameter" "private_key" {
 resource "aws_ssm_parameter" "root_ca_crt" {
   name   = "/${var.name}/iot/root-ca-crt"
   type   = "SecureString"
-  value  = data.http.root_ca.body
+  value  = data.http.root_ca.response_body
   key_id = var.kms_key_id
   tags   = var.tags
 }


### PR DESCRIPTION
The HTTP Terraform provider has deprecated `body` in the latest release and replaced it in favour of `response_body`. 
https://github.com/hashicorp/terraform-provider-http/blob/main/CHANGELOG.md#300-july-27-2022

That change is reflected in this PR. 