### PR TITLE
removing SSM activation and related resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_ssm_parameter" "ssm_activation" {
   count  = var.create_ssm_activation == true ? 1 : 0
   name   = "/${var.name}/iot/ssm-activation"
   type   = "SecureString"
-  value  = aws_ssm_activation.default.activation_code
+  value  = aws_ssm_activation.default[0].activation_code
   key_id = var.kms_key_id
   tags   = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -99,8 +99,6 @@ resource "aws_ssm_parameter" "root_ca_crt" {
 }
 
 data "aws_iam_policy_document" "ssm_activation" {
-  count = local.create_role
-
   statement {
     actions = [
       "sts:AssumeRole"

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ resource "aws_ssm_parameter" "root_ca_crt" {
 }
 
 data "aws_iam_policy_document" "ssm_activation" {
-  count = var.create_ssm_activation == true ? 1 : 0
+  count = local.create_role
 
   statement {
     actions = [

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
-  create_role = var.ssm_activation_role_id != null ? 0 : 1
-  iot_policy  = var.iot_policy != null ? var.iot_policy : data.aws_iam_policy_document.default.json
+  create_role            = var.ssm_activation_role_id != null || var.create_ssm_activation == false ? 0 : 1
+  iot_policy             = var.iot_policy != null ? var.iot_policy : data.aws_iam_policy_document.default.json
+  ssm_activation_role_id = var.ssm_activation_role_id != null ? var.ssm_activation_role_id : aws_iam_role.ssm_activation[0].id
 }
 
 data "aws_iam_policy_document" "default" {
@@ -93,6 +94,59 @@ resource "aws_ssm_parameter" "root_ca_crt" {
   name   = "/${var.name}/iot/root-ca-crt"
   type   = "SecureString"
   value  = data.http.root_ca.response_body
+  key_id = var.kms_key_id
+  tags   = var.tags
+}
+
+data "aws_iam_policy_document" "ssm_activation" {
+  count = var.create_ssm_activation == true ? 1 : 0
+
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ssm_activation" {
+  count              = local.create_role
+  name               = "SSMActivation-${var.name}"
+  assume_role_policy = data.aws_iam_policy_document.ssm_activation.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_activation" {
+  count      = local.create_role
+  role       = aws_iam_role.ssm_activation[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_ssm_activation" "default" {
+  count              = var.create_ssm_activation == true ? 1 : 0
+  name               = var.name
+  description        = "SSM Activation for ${var.name}"
+  iam_role           = local.ssm_activation_role_id
+  expiration_date    = timeadd(timestamp(), var.expiration_duration)
+  registration_limit = 1
+  depends_on         = [aws_iam_role_policy_attachment.ssm_activation]
+  tags               = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      expiration_date
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "ssm_activation" {
+  count  = var.create_ssm_activation == true ? 1 : 0
+  name   = "/${var.name}/iot/ssm-activation"
+  type   = "SecureString"
+  value  = aws_ssm_activation.default.activation_code
   key_id = var.kms_key_id
   tags   = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,6 @@ variable "iot_policy" {
   description = "The policy to attach to the Thing"
 }
 
-variable "ssm_activation_role_id" {
-  type        = string
-  default     = null
-  description = "The ID of the role to attach to the SSM activation"
-}
-
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the SSM Parameter"

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,19 @@ variable "iot_policy" {
   description = "The policy to attach to the Thing"
 }
 
+variable "ssm_activation_role_id" {
+  type        = string
+  default     = null
+  description = "The ID of the role to attach to the SSM activation"
+}
+
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the SSM Parameter"
+}
+
+variable "create_ssm_activation" {
+  type        = bool
+  default     = true
+  description = "The Flag which determines if SSM activation resouces should be created"
 }


### PR DESCRIPTION
Reason
we have added code to create SSM activation on the services account, so removing the SSM activation code from the repo, as it is not needed 