### PR TITLE
Fix ssm activation creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_ssm_parameter" "ssm_activation" {
   count  = var.create_ssm_activation == true ? 1 : 0
   name   = "/${var.name}/iot/ssm-activation"
   type   = "SecureString"
-  value  = aws_ssm_activation.default[0].activation_code
+  value  = aws_ssm_activation.default.activation_code
   key_id = var.kms_key_id
   tags   = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   create_role            = var.ssm_activation_role_id != null || var.create_ssm_activation == false ? 0 : 1
   iot_policy             = var.iot_policy != null ? var.iot_policy : data.aws_iam_policy_document.default.json
-  ssm_activation_role_id = var.ssm_activation_role_id != null ? var.ssm_activation_role_id : aws_iam_role.ssm_activation[0].id
+  ssm_activation_role_id = var.ssm_activation_role_id != null ? var.ssm_activation_role_id : aws_iam_role.ssm_activation.id
 }
 
 data "aws_iam_policy_document" "default" {


### PR DESCRIPTION
No clue why [0] was added in here, but it breaks the creation of the SSM activation parameter.